### PR TITLE
Fix stats failing when receiving multiple data events

### DIFF
--- a/lib/commands/stats.js
+++ b/lib/commands/stats.js
@@ -1,7 +1,17 @@
 module.exports.run = function(cli, callback) {
   var process = cli.exec(['stats']);
 
-  process.stdout.once('data', function(data) {
+  var data = '';
+  var errored = false;
+
+  process.stdout.on('data', function(chunk) {
+    data += chunk;
+  });
+
+  process.stdout.once('end', function() {
+    if (errored) {
+      return;
+    }
     var stats = null,
         split = data.toString().split('\n'),
         files = data.match(/Files these postings came from:([^]*?)(\r?\n){2}/);
@@ -35,6 +45,7 @@ module.exports.run = function(cli, callback) {
   });
 
   process.stderr.once('data', function(error) {
+    errored = true;
     callback(error);
   });
 };


### PR DESCRIPTION
Sometimes stats come in since `data`, sometimes multiple. This fixes them failing.